### PR TITLE
Remove unused stdio.h include

### DIFF
--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -1,7 +1,6 @@
 #include "priority_queue.h"
 #include <assert.h>
 #include <limits.h>
-#include <stdio.h>
 #include <string.h>
 
 /****************************


### PR DESCRIPTION
## Summary
- `<stdio.h>` was included in `src/priority_queue.c` but no `printf`, `fprintf`, or other stdio functions are used in the implementation

## Test plan
- [ ] `make test` passes (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)