### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang
+        run: sudo apt-get install -y clang
+
+      - name: Build and run tests
+        run: make test
+
+      - name: Build and run tests with sanitizers
+        run: make memcheck


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` to run tests automatically on every push and PR targeting master
- Runs `make test` (build + unit tests) and `make memcheck` (ASAN build + tests)
- Uses `ubuntu-latest` with Clang, matching the local build setup

## Test plan
- [ ] CI runs green on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)