### PR TITLE
Add UBSan to sanitizer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INC=./include/
 OPTFLAGS = -g
 WARNFLAGS = -Wall -Wextra -Wpedantic -Wconversion -Wshadow -Werror
 
-ASANFLAGS  = -fsanitize=address
+ASANFLAGS  = -fsanitize=address,undefined
 ASANFLAGS += -fno-common
 ASANFLAGS += -fno-omit-frame-pointer
 


### PR DESCRIPTION
## Summary
- Extends `-fsanitize=address` to `-fsanitize=address,undefined` in the `memcheck` target
- Catches undefined behavior (signed integer overflow, null pointer dereference, misaligned access, out-of-bounds array indexing, etc.) alongside existing memory error detection

## Test plan
- [ ] CI runs green on `make memcheck` with combined ASAN+UBSan

🤖 Generated with [Claude Code](https://claude.com/claude-code)