### PR TITLE
Upgrade actions/checkout to v6 for Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Clang
         run: sudo apt-get install -y clang


### PR DESCRIPTION
## Summary
- Upgrades `actions/checkout@v4` → `@v6`, which runs on Node.js 24
- Eliminates the deprecation warning appearing on every CI run
- Required before GitHub forces the Node.js 24 migration on June 2, 2026 (one week away)

## Test plan
- [ ] CI runs green with no Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)