### PR TITLE
Add priority_queue_peek()

### DIFF
--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -26,6 +26,7 @@ struct priority_queue {
 void   priority_queue_initialize(struct priority_queue *const self, priority_queue_get_priority_t get_priority);
 int    priority_queue_enqueue(struct priority_queue *const self, void *value);
 void  *priority_queue_dequeue(struct priority_queue *const self);
+void  *priority_queue_peek(const struct priority_queue *const self);
 size_t priority_queue_length(const struct priority_queue *const self);
 
 #endif /* PRIORITY_QUEUE_H */

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -140,6 +140,19 @@ priority_queue_length(const struct priority_queue *const self)
 }
 
 /**
+ * @param self the priority queue
+ * @returns the minimum-priority element without removing it, or NULL if empty
+ **/
+void *
+priority_queue_peek(const struct priority_queue *const self)
+{
+	assert(self != NULL);
+
+	if (self->first_free == 1) return NULL;
+	return self->items[1];
+}
+
+/**
  * @param self - the priority queue we want to add to
  * @param value - the value we want to add
  * @returns 0 on success. -1 when priority queue is full

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -193,6 +193,27 @@ dequeue_should_return_in_priority_order(void)
 	TEST_ASSERT_EQUAL_PTR(NULL, priority_queue_dequeue(&pq));
 }
 
+void
+peek_on_empty_returns_null(void)
+{
+	TEST_ASSERT_NULL(priority_queue_peek(&pq));
+}
+
+void
+peek_returns_min_without_removing(void)
+{
+	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
+	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
+	priority_queue_enqueue(&pq, sandbox_one);
+	priority_queue_enqueue(&pq, sandbox_two);
+
+	TEST_ASSERT_EQUAL_PTR(sandbox_two, priority_queue_peek(&pq));
+	TEST_ASSERT_EQUAL_UINT(2, priority_queue_length(&pq));
+
+	free(sandbox_one);
+	free(sandbox_two);
+}
+
 int
 main(void)
 {
@@ -208,6 +229,8 @@ main(void)
 	RUN_TEST(dequeue_last_element_should_set_ULONG_MAX);
 	RUN_TEST(dequeue_of_one);
 	RUN_TEST(dequeue_should_return_in_priority_order);
+	RUN_TEST(peek_on_empty_returns_null);
+	RUN_TEST(peek_returns_min_without_removing);
 
 	return UnityEnd();
 }


### PR DESCRIPTION
## Summary
- Adds `priority_queue_peek()` to the public API — returns the minimum-priority element without removing it, or `NULL` if the queue is empty
- Reads directly from `items[1]` (the heap root), so it is O(1)
- Adds two tests: empty-queue returns NULL, and peek does not change queue length

## Test plan
- [ ] CI runs green (13 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)