### PR TITLE
Add priority_queue_clear()

### DIFF
--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -25,6 +25,7 @@ struct priority_queue {
 };
 
 void   priority_queue_initialize(struct priority_queue *const self, priority_queue_get_priority_t get_priority);
+void   priority_queue_clear(struct priority_queue *const self);
 int    priority_queue_enqueue(struct priority_queue *const self, void *value);
 void  *priority_queue_dequeue(struct priority_queue *const self);
 void  *priority_queue_peek(const struct priority_queue *const self);

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -128,6 +128,21 @@ priority_queue_initialize(struct priority_queue *const self, priority_queue_get_
 }
 
 /**
+ * Removes all elements from the priority queue, preserving the get_priority
+ * callback so the queue can be reused without reinitializing.
+ * @param self the priority queue to clear
+ **/
+void
+priority_queue_clear(struct priority_queue *const self)
+{
+	assert(self != NULL);
+
+	memset(self->items, 0, sizeof(void *) * MAX);
+	self->first_free      = 1;
+	self->highest_priority = ULONG_MAX;
+}
+
+/**
  * @param self the priority_queue
  * @returns the number of elements in the priority queue
  **/

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -244,6 +244,46 @@ is_full_returns_true_when_at_capacity(void)
 	free(sandbox_one);
 }
 
+void
+clear_empties_queue(void)
+{
+	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
+	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
+	priority_queue_enqueue(&pq, sandbox_one);
+	priority_queue_enqueue(&pq, sandbox_two);
+	TEST_ASSERT_FALSE(priority_queue_is_empty(&pq));
+
+	priority_queue_clear(&pq);
+
+	TEST_ASSERT_TRUE(priority_queue_is_empty(&pq));
+	TEST_ASSERT_EQUAL_UINT64(ULONG_MAX, pq.highest_priority);
+	free(sandbox_one);
+	free(sandbox_two);
+}
+
+void
+clear_preserves_get_priority_callback(void)
+{
+	priority_queue_clear(&pq);
+	TEST_ASSERT_EQUAL_PTR(sandbox_request_get_priority, pq.get_priority);
+}
+
+void
+clear_allows_reuse(void)
+{
+	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
+	priority_queue_enqueue(&pq, sandbox_one);
+	priority_queue_clear(&pq);
+
+	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
+	priority_queue_enqueue(&pq, sandbox_two);
+	TEST_ASSERT_EQUAL_PTR(sandbox_two, priority_queue_peek(&pq));
+	TEST_ASSERT_EQUAL_UINT(1, priority_queue_length(&pq));
+
+	free(sandbox_one);
+	free(sandbox_two);
+}
+
 int
 main(void)
 {
@@ -265,6 +305,9 @@ main(void)
 	RUN_TEST(is_empty_returns_false_after_enqueue);
 	RUN_TEST(is_full_returns_false_on_empty_queue);
 	RUN_TEST(is_full_returns_true_when_at_capacity);
+	RUN_TEST(clear_empties_queue);
+	RUN_TEST(clear_preserves_get_priority_callback);
+	RUN_TEST(clear_allows_reuse);
 
 	return UnityEnd();
 }


### PR DESCRIPTION
## Summary
- Adds `priority_queue_clear()` to reset the queue for reuse without reinitializing — zeroes `items[]`, resets `first_free` and `highest_priority`, preserves the `get_priority` callback
- Adds 3 tests: empties the queue, preserves the callback, and confirms the queue works correctly after a clear-and-reuse cycle

## Test plan
- [ ] CI runs green (20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)