### PR TITLE
Add warn_unused_result to priority_queue_enqueue()

### DIFF
--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -7,6 +7,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+#define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define WARN_UNUSED_RESULT
+#endif
+
 /**
  * How to get the priority out of the generic element
  * We assume priority is expressed as an unsigned 64-bit integer (i.e. cycles or
@@ -27,7 +33,7 @@ struct priority_queue {
 
 void   priority_queue_initialize(struct priority_queue *const self, priority_queue_get_priority_t get_priority);
 void   priority_queue_clear(struct priority_queue *const self);
-int    priority_queue_enqueue(struct priority_queue *const self, void *value);
+WARN_UNUSED_RESULT int priority_queue_enqueue(struct priority_queue *const self, void *value);
 void  *priority_queue_dequeue(struct priority_queue *const self);
 void  *priority_queue_peek(const struct priority_queue *const self);
 size_t priority_queue_length(const struct priority_queue *const self);

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -60,7 +60,7 @@ void
 enqueue_should_increment_first_free_and_length(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_EQUAL_UINT(2, pq.first_free);
 	TEST_ASSERT_EQUAL_UINT(1, priority_queue_length(&pq));
 	free(sandbox_one);
@@ -70,7 +70,7 @@ void
 enqueue_first_call_should_set_highest_priority(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_EQUAL_INT32(10, pq.highest_priority);
 	free(sandbox_one);
 }
@@ -79,7 +79,7 @@ void
 enqueue_first_call_should_set_index_1(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_EQUAL_PTR(sandbox_one, pq.items[1]);
 	free(sandbox_one);
 }
@@ -110,7 +110,7 @@ dequeue_last_element_should_set_UINT64_MAX(void)
 {
 	TEST_ASSERT_EQUAL_UINT64(UINT64_MAX, pq.highest_priority);
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_LESS_THAN_UINT64(UINT64_MAX, pq.highest_priority);
 	priority_queue_dequeue(&pq);
 	free(sandbox_one);
@@ -121,7 +121,7 @@ void
 dequeue_of_one(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_EQUAL_PTR(sandbox_one, priority_queue_dequeue(&pq));
 	free(sandbox_one);
 }
@@ -130,25 +130,25 @@ void
 dequeue_should_return_in_priority_order(void)
 {
 	struct sandbox_request *sandbox_7 = sandbox_request_allocate(7);
-	priority_queue_enqueue(&pq, sandbox_7);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_7));
 	TEST_ASSERT_EQUAL_PTR(sandbox_7, pq.items[1]);
 	TEST_ASSERT_EQUAL_UINT64(7, pq.highest_priority);
 
 	struct sandbox_request *sandbox_9 = sandbox_request_allocate(9);
-	priority_queue_enqueue(&pq, sandbox_9);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_9));
 	TEST_ASSERT_EQUAL_PTR(sandbox_7, pq.items[1]);
 	TEST_ASSERT_EQUAL_PTR(sandbox_9, pq.items[2]);
 	TEST_ASSERT_EQUAL_UINT64(7, pq.highest_priority);
 
 	struct sandbox_request *sandbox_5 = sandbox_request_allocate(5);
-	priority_queue_enqueue(&pq, sandbox_5);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_5));
 	TEST_ASSERT_EQUAL_PTR(sandbox_5, pq.items[1]);
 	TEST_ASSERT_EQUAL_PTR(sandbox_9, pq.items[2]);
 	TEST_ASSERT_EQUAL_PTR(sandbox_7, pq.items[3]);
 	TEST_ASSERT_EQUAL_UINT64(5, pq.highest_priority);
 
 	struct sandbox_request *sandbox_11 = sandbox_request_allocate(11);
-	priority_queue_enqueue(&pq, sandbox_11);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_11));
 	TEST_ASSERT_EQUAL_PTR(sandbox_5, pq.items[1]);
 	TEST_ASSERT_EQUAL_PTR(sandbox_9, pq.items[2]);
 	TEST_ASSERT_EQUAL_PTR(sandbox_7, pq.items[3]);
@@ -156,7 +156,7 @@ dequeue_should_return_in_priority_order(void)
 	TEST_ASSERT_EQUAL_UINT64(5, pq.highest_priority);
 
 	struct sandbox_request *sandbox_2 = sandbox_request_allocate(2);
-	priority_queue_enqueue(&pq, sandbox_2);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_2));
 
 	struct sandbox_request *state1[] = { NULL, sandbox_2, sandbox_5, sandbox_7, sandbox_11, sandbox_9 };
 	TEST_ASSERT_EQUAL_PTR_ARRAY(state1, pq.items, 6);
@@ -204,8 +204,8 @@ peek_returns_min_without_removing(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
 	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
-	priority_queue_enqueue(&pq, sandbox_one);
-	priority_queue_enqueue(&pq, sandbox_two);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_two));
 
 	TEST_ASSERT_EQUAL_PTR(sandbox_two, priority_queue_peek(&pq));
 	TEST_ASSERT_EQUAL_UINT(2, priority_queue_length(&pq));
@@ -224,7 +224,7 @@ void
 is_empty_returns_false_after_enqueue(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	TEST_ASSERT_FALSE(priority_queue_is_empty(&pq));
 	free(sandbox_one);
 }
@@ -239,7 +239,7 @@ void
 is_full_returns_true_when_at_capacity(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	for (size_t i = 0; i < MAX - 1; i++) priority_queue_enqueue(&pq, sandbox_one);
+	for (size_t i = 0; i < MAX - 1; i++) (void)priority_queue_enqueue(&pq, sandbox_one);
 	TEST_ASSERT_TRUE(priority_queue_is_full(&pq));
 	free(sandbox_one);
 }
@@ -249,8 +249,8 @@ clear_empties_queue(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
 	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
-	priority_queue_enqueue(&pq, sandbox_one);
-	priority_queue_enqueue(&pq, sandbox_two);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_two));
 	TEST_ASSERT_FALSE(priority_queue_is_empty(&pq));
 
 	priority_queue_clear(&pq);
@@ -272,11 +272,11 @@ void
 clear_allows_reuse(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	priority_queue_enqueue(&pq, sandbox_one);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_one));
 	priority_queue_clear(&pq);
 
 	struct sandbox_request *sandbox_two = sandbox_request_allocate(5);
-	priority_queue_enqueue(&pq, sandbox_two);
+	TEST_ASSERT_EQUAL_INT(0, priority_queue_enqueue(&pq, sandbox_two));
 	TEST_ASSERT_EQUAL_PTR(sandbox_two, priority_queue_peek(&pq));
 	TEST_ASSERT_EQUAL_UINT(1, priority_queue_length(&pq));
 


### PR DESCRIPTION
## Summary
- Adds `__attribute__((warn_unused_result))` to `priority_queue_enqueue()` via a `WARN_UNUSED_RESULT` portability macro (expands to nothing on non-GCC/Clang compilers)
- Callers that silently discard the `-1` full-queue error return now get a compiler warning
- Updates all test callsites: asserts `== 0` on every enqueue expected to succeed, and uses `(void)` cast in bulk-fill loops where per-iteration checking would be noise

## Test plan
- [ ] CI runs green (20 tests, zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)