### PR TITLE
Make capacity configurable via PRIORITY_QUEUE_CAPACITY macro

### DIFF
--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -13,6 +13,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/* Child indices are computed as 2*i and 2*i+1 using size_t arithmetic.
+ * If PRIORITY_QUEUE_CAPACITY exceeds SIZE_MAX/2 the multiplication overflows. */
+_Static_assert(PRIORITY_QUEUE_CAPACITY <= SIZE_MAX / 2,
+               "PRIORITY_QUEUE_CAPACITY must be at most SIZE_MAX/2 to avoid size_t overflow in child index calculations");
+
 #if defined(__GNUC__) || defined(__clang__)
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #else

--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -5,6 +5,10 @@
 #define PRIORITY_QUEUE_CAPACITY 4096
 #endif
 
+#if PRIORITY_QUEUE_CAPACITY < 2
+#error "PRIORITY_QUEUE_CAPACITY must be at least 2 (index 0 is unused in the 1-indexed heap)"
+#endif
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -15,9 +15,12 @@
 #include <stdint.h>
 
 /* Child indices are computed as 2*i and 2*i+1 using size_t arithmetic.
- * If PRIORITY_QUEUE_CAPACITY exceeds SIZE_MAX/2 the multiplication overflows. */
+ * SIZE_MAX is always odd (2^N - 1 for an N-bit type), so at i = SIZE_MAX/2:
+ * 2*i = SIZE_MAX-1 and 2*i+1 = SIZE_MAX — both representable, no overflow.
+ * Capacities above SIZE_MAX/2 would allow i to exceed this bound. */
 static_assert(PRIORITY_QUEUE_CAPACITY <= SIZE_MAX / 2,
               "PRIORITY_QUEUE_CAPACITY must be at most SIZE_MAX/2 to avoid size_t overflow in child index calculations");
+static_assert(SIZE_MAX % 2 == 1, "SIZE_MAX must be odd (size_t uses pure binary representation per C11 §6.2.6.2)");
 
 #if defined(__GNUC__) || defined(__clang__)
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -1,7 +1,9 @@
 #ifndef PRIORITY_QUEUE_H
 #define PRIORITY_QUEUE_H
 
-#define MAX 4096
+#ifndef PRIORITY_QUEUE_CAPACITY
+#define PRIORITY_QUEUE_CAPACITY 4096
+#endif
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -25,7 +27,7 @@ typedef uint64_t (*priority_queue_get_key_t)(void *element);
 
 struct priority_queue {
 	uint64_t                      min_key; /* cached key of the heap root */
-	void                         *items[MAX];
+	void                         *items[PRIORITY_QUEUE_CAPACITY];
 	size_t                        first_free;
 	priority_queue_get_key_t get_key;
 };

--- a/include/priority_queue.h
+++ b/include/priority_queue.h
@@ -9,14 +9,15 @@
 #error "PRIORITY_QUEUE_CAPACITY must be at least 2 (index 0 is unused in the 1-indexed heap)"
 #endif
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 /* Child indices are computed as 2*i and 2*i+1 using size_t arithmetic.
  * If PRIORITY_QUEUE_CAPACITY exceeds SIZE_MAX/2 the multiplication overflows. */
-_Static_assert(PRIORITY_QUEUE_CAPACITY <= SIZE_MAX / 2,
-               "PRIORITY_QUEUE_CAPACITY must be at most SIZE_MAX/2 to avoid size_t overflow in child index calculations");
+static_assert(PRIORITY_QUEUE_CAPACITY <= SIZE_MAX / 2,
+              "PRIORITY_QUEUE_CAPACITY must be at most SIZE_MAX/2 to avoid size_t overflow in child index calculations");
 
 #if defined(__GNUC__) || defined(__clang__)
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))

--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -18,7 +18,7 @@ priority_queue_append(struct priority_queue *const self, void *new_item)
 {
 	assert(self != NULL);
 
-	if (self->first_free >= MAX) return -1;
+	if (self->first_free >= PRIORITY_QUEUE_CAPACITY) return -1;
 
 	self->items[self->first_free] = new_item;
 	self->first_free++;
@@ -118,7 +118,7 @@ priority_queue_initialize(struct priority_queue *const self, priority_queue_get_
 	assert(self != NULL);
 	assert(get_key != NULL);
 
-	memset(self->items, 0, sizeof(void *) * MAX);
+	memset(self->items, 0, sizeof(void *) * PRIORITY_QUEUE_CAPACITY);
 	self->first_free   = 1;
 	self->get_key = get_key;
 
@@ -135,7 +135,7 @@ priority_queue_clear(struct priority_queue *const self)
 {
 	assert(self != NULL);
 
-	memset(self->items, 0, sizeof(void *) * MAX);
+	memset(self->items, 0, sizeof(void *) * PRIORITY_QUEUE_CAPACITY);
 	self->first_free       = 1;
 	self->min_key = UINT64_MAX;
 }
@@ -234,5 +234,5 @@ priority_queue_is_full(const struct priority_queue *const self)
 {
 	assert(self != NULL);
 
-	return self->first_free >= MAX;
+	return self->first_free >= PRIORITY_QUEUE_CAPACITY;
 }

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -90,8 +90,8 @@ enqueue_returns_neg1_on_full(void)
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
 
 	// Fill up the priority queue up to the max
-	// This is one less than MAX because a min heap does not use the 0th element
-	for (size_t i = 0; i < MAX - 1; i++) TEST_ASSERT_EQUAL_INT32(0, priority_queue_enqueue(&pq, sandbox_one));
+	// This is one less than PRIORITY_QUEUE_CAPACITY because a min heap does not use the 0th element
+	for (size_t i = 0; i < PRIORITY_QUEUE_CAPACITY - 1; i++) TEST_ASSERT_EQUAL_INT32(0, priority_queue_enqueue(&pq, sandbox_one));
 
 	// And then add one more
 	TEST_ASSERT_EQUAL_INT32(-1, priority_queue_enqueue(&pq, sandbox_one));
@@ -239,7 +239,7 @@ void
 is_full_returns_true_when_at_capacity(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
-	for (size_t i = 0; i < MAX - 1; i++) (void)priority_queue_enqueue(&pq, sandbox_one);
+	for (size_t i = 0; i < PRIORITY_QUEUE_CAPACITY - 1; i++) (void)priority_queue_enqueue(&pq, sandbox_one);
 	TEST_ASSERT_TRUE(priority_queue_is_full(&pq));
 	free(sandbox_one);
 }


### PR DESCRIPTION
## Summary
- Replaces the bare `#define MAX 4096` with a guarded, namespaced macro:
  ```c
  #ifndef PRIORITY_QUEUE_CAPACITY
  #define PRIORITY_QUEUE_CAPACITY 4096
  #endif
  ```
- Callers can override the capacity at compile time with `-DPRIORITY_QUEUE_CAPACITY=N` — no code changes required
- The `items[]` array remains statically allocated; no heap involvement
- Namespacing avoids collisions with the common `MAX` symbol from other headers

## Test plan
- [ ] CI runs green with default capacity (20 tests)
- [ ] Manually verified: `clang -DPRIORITY_QUEUE_CAPACITY=16 ...` compiles and all 20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)