### PR TITLE
Fix Makefile to pass user-supplied CFLAGS through to compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ default: test
 .PHONY: test
 test: clean
 	@if [ ! -d bin ]; then mkdir bin; fi
-	@$(CC) $(OPTFLAGS) $(WARNFLAGS) -I$(INC) test/*.c test/vendor/*.c src/*.c -o bin/test
+	@$(CC) $(OPTFLAGS) $(WARNFLAGS) $(CFLAGS) -I$(INC) test/*.c test/vendor/*.c src/*.c -o bin/test
 	@./bin/test
 
 .PHONY: clean
@@ -23,7 +23,7 @@ clean:
 .PHONY: memcheck
 memcheck: test/*.c src/*.c
 	@mkdir -p ./bin
-	@$(CC) $(ASANFLAGS) $(OPTFLAGS) $(WARNFLAGS) -I$(INC) test/*.c test/vendor/*.c src/*.c -o bin/memcheck $(LIBS)
+	@$(CC) $(ASANFLAGS) $(OPTFLAGS) $(WARNFLAGS) $(CFLAGS) -I$(INC) test/*.c test/vendor/*.c src/*.c -o bin/memcheck $(LIBS)
 	@./bin/memcheck
 	@echo "Memory check passed"
 


### PR DESCRIPTION
## Summary
- `$(CFLAGS)` was missing from the compiler invocations in both the `test` and `memcheck` targets
- The README documents `make test CFLAGS=-DPRIORITY_QUEUE_CAPACITY=N` as the way to override capacity, but this had no effect because `$(CFLAGS)` was never forwarded to the compiler
- Now both targets pass `$(CFLAGS)` so user-supplied defines (e.g. `-DPRIORITY_QUEUE_CAPACITY=64`) are respected

Closes #19

## Test plan
- `make test` — 20/20 tests pass
- `make test CFLAGS="-DPRIORITY_QUEUE_CAPACITY=64"` — 20/20 tests pass with custom capacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)