### PR TITLE
Remove always-true left_child_index >= 2 guard in percolate_down

### DIFF
--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -87,7 +87,7 @@ priority_queue_percolate_down(struct priority_queue *const self)
 
 	size_t parent_index     = 1;
 	size_t left_child_index = 2 * parent_index;
-	while (left_child_index >= 2 && left_child_index < self->first_free) {
+	while (left_child_index < self->first_free) {
 		size_t smallest_child_index = priority_queue_find_smallest_child(self, parent_index);
 		// Once the parent is equal to or less than its smallest child, break;
 		if (self->get_key(self->items[parent_index])


### PR DESCRIPTION
## Summary
- In `priority_queue_percolate_down`, the while-loop guard `left_child_index >= 2` is always true
- `parent_index` is initialised to 1, so `left_child_index = 2 * 1 = 2` at loop entry; it is set to `2 * parent_index` at the end of each iteration where `parent_index` only increases — the value can never fall below 2
- The dead sub-expression is removed, leaving only the meaningful `left_child_index < self->first_free` check

Closes #20

## Test plan
- `make test` — 20/20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)