### PR TITLE
Check malloc return value in sandbox_request_allocate test helper

### DIFF
--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -14,7 +14,8 @@ struct sandbox_request *
 sandbox_request_allocate(uint64_t absolute_deadline)
 {
 	struct sandbox_request *sandbox_request = malloc(sizeof(struct sandbox_request));
-	sandbox_request->absolute_deadline      = absolute_deadline;
+	if (sandbox_request == NULL) abort();
+	sandbox_request->absolute_deadline = absolute_deadline;
 	return sandbox_request;
 }
 


### PR DESCRIPTION
## Summary
- `sandbox_request_allocate` called `malloc` but immediately dereferenced the result without checking for NULL
- A NULL dereference is undefined behaviour; ASan/UBSan would catch it, but only after the fact
- Added an explicit `if (sandbox_request == NULL) abort()` guard — test helpers have no meaningful recovery path, so `abort()` gives an immediate, unambiguous failure signal

Closes #21

## Test plan
- `make test` — 20/20 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)