### PR TITLE
Reject NULL values in priority_queue_enqueue

### DIFF
--- a/src/priority_queue.c
+++ b/src/priority_queue.c
@@ -175,6 +175,7 @@ priority_queue_enqueue(struct priority_queue *const self, void *value)
 {
 	assert(self != NULL);
 
+	if (value == NULL) return -1;
 	if (priority_queue_append(self, value) == -1) return -1;
 	if (self->first_free > 2) {
 		priority_queue_percolate_up(self);

--- a/test/priority_queue_test.c
+++ b/test/priority_queue_test.c
@@ -85,6 +85,13 @@ enqueue_first_call_should_set_index_1(void)
 }
 
 void
+enqueue_returns_neg1_on_null(void)
+{
+	TEST_ASSERT_EQUAL_INT(-1, priority_queue_enqueue(&pq, NULL));
+	TEST_ASSERT_EQUAL_UINT(0, priority_queue_length(&pq));
+}
+
+void
 enqueue_returns_neg1_on_full(void)
 {
 	struct sandbox_request *sandbox_one = sandbox_request_allocate(10);
@@ -294,6 +301,7 @@ main(void)
 	RUN_TEST(enqueue_first_call_should_set_min_key);
 	RUN_TEST(enqueue_should_increment_first_free_and_length);
 	RUN_TEST(enqueue_first_call_should_set_index_1);
+	RUN_TEST(enqueue_returns_neg1_on_null);
 	RUN_TEST(enqueue_returns_neg1_on_full);
 	RUN_TEST(dequeue_on_empty_returns_null);
 	RUN_TEST(dequeue_last_element_should_set_UINT64_MAX);


### PR DESCRIPTION
## Summary
- `priority_queue_enqueue` accepted NULL as a value; the NULL would then reach `get_key(NULL)` inside `priority_queue_percolate_up` or when caching `min_key` on the first enqueue — both are undefined behaviour
- Added an early-return `-1` guard before the append so callers receive the same error code as a full queue
- Added `enqueue_returns_neg1_on_null` test that verifies the return value and that queue length stays zero

Closes #22

## Test plan
- `make test` — 21/21 tests pass (1 new test added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)