### PR TITLE
chore: add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+---


### PR DESCRIPTION
## Summary
Adds Dependabot configuration to automate dependency updates for: github-actions.
Updates will open PRs weekly.

## Ecosystems tracked
- `github-actions`